### PR TITLE
feat(rss): RSS 피드 엔드포인트 및 헤더 아이콘 추가 (#34)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ coverage/
 *.tsbuildinfo
 
 .omc/*
+.worktrees/
+.claude/

--- a/docs/superpowers/plans/2026-05-22-rss-feed-github-card.md
+++ b/docs/superpowers/plans/2026-05-22-rss-feed-github-card.md
@@ -1,0 +1,505 @@
+# RSS 피드 + GitHub 프로필 블로그 카드 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** kronglog 블로그에 RSS 피드와 헤더 RSS 아이콘을 추가하고, GitHub 프로필 레포에 최근 포스트 3개를 표시하는 SVG 카드 자동 업데이트 워크플로우를 구축한다.
+
+**Architecture:** kronglog의 `feat/#34/rss-subscribe` 브랜치에서 `@astrojs/rss`로 `/rss.xml` 정적 엔드포인트와 헤더 아이콘을 추가한다. `seongmin36/seongmin36` 프로필 레포에는 RSS를 읽어 SVG를 생성·커밋하는 GitHub Action을 추가한다.
+
+**Tech Stack:** Astro 6 + `@astrojs/rss` + TypeScript (kronglog) / Node.js 22 + GitHub Actions (profile repo)
+
+---
+
+## 파일 맵
+
+### Part A — kronglog (`feat/#34/rss-subscribe`)
+
+| 상태 | 경로 | 역할 |
+|------|------|------|
+| 신규 | `src/pages/rss.xml.ts` | RSS 2.0 엔드포인트, 빌드 시 `/rss.xml` 생성 |
+| 신규 | `src/assets/icons/icon-rss.svg` | RSS 웨이브 아이콘 (currentColor, 24×24) |
+| 수정 | `src/components/ui/AppIcons.tsx` | `rss` 아이콘 등록 |
+| 수정 | `src/components/Header.astro` | LinkedIn 옆 RSS 아이콘 링크 추가 |
+
+### Part B — seongmin36/seongmin36 (프로필 레포)
+
+| 상태 | 경로 | 역할 |
+|------|------|------|
+| 신규 | `scripts/generate-blog-card.mjs` | RSS fetch → SVG 생성 스크립트 |
+| 신규 | `.github/workflows/update-blog-card.yml` | 스케줄 + 수동 Action |
+| 자동 | `recent-posts.svg` | Action이 생성·커밋하는 결과물 |
+| 수정 | `README.md` | SVG 카드 삽입 |
+
+---
+
+## Part A — kronglog
+
+### Task 1: `@astrojs/rss` 설치
+
+**Files:**
+- Modify: `package.json`, `pnpm-lock.yaml`
+
+- [ ] **Step 1: 패키지 설치**
+
+```bash
+cd /Users/josengmin/Desktop/Project/kronglog
+git checkout feat/#34/rss-subscribe
+pnpm add @astrojs/rss
+```
+
+- [ ] **Step 2: 설치 확인**
+
+```bash
+cat package.json | grep @astrojs/rss
+```
+
+Expected: `"@astrojs/rss": "^4.x.x"` 또는 최신 버전
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add package.json pnpm-lock.yaml
+git commit -m "feat(rss): install @astrojs/rss (#34)"
+git push origin feat/#34/rss-subscribe
+```
+
+---
+
+### Task 2: RSS 엔드포인트 생성
+
+**Files:**
+- Create: `src/pages/rss.xml.ts`
+
+- [ ] **Step 1: `src/pages/rss.xml.ts` 생성**
+
+```ts
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import type { APIContext } from 'astro';
+
+export async function GET(context: APIContext) {
+  const posts = await getCollection('post');
+  const sorted = posts.sort(
+    (a, b) => b.data.date.getTime() - a.data.date.getTime()
+  );
+
+  return rss({
+    title: 'Krong Dev.',
+    description: '개발하면서 배운 것들을 기록합니다.',
+    site: context.site!,
+    items: sorted.map((post) => ({
+      title: post.data.title,
+      pubDate: post.data.date,
+      description: post.data.description ?? '',
+      link: `/blogs/${post.id}`,
+    })),
+  });
+}
+```
+
+- [ ] **Step 2: 빌드 후 RSS 파일 존재 확인**
+
+```bash
+pnpm build 2>&1 | tail -5
+```
+
+Expected: 빌드 성공 (exit 0)
+
+```bash
+ls dist/rss.xml
+```
+
+Expected: `dist/rss.xml` 파일 존재
+
+- [ ] **Step 3: XML 유효성 확인**
+
+```bash
+head -5 dist/rss.xml
+```
+
+Expected:
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" ...>
+  <channel>
+    <title>Krong Dev.</title>
+```
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/pages/rss.xml.ts
+git commit -m "feat(rss): add rss feed endpoint (#34)"
+git push origin feat/#34/rss-subscribe
+```
+
+---
+
+### Task 3: RSS 아이콘 SVG 추가
+
+**Files:**
+- Create: `src/assets/icons/icon-rss.svg`
+
+- [ ] **Step 1: `src/assets/icons/icon-rss.svg` 생성**
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 11a9 9 0 0 1 9 9"/>
+  <path d="M4 4a16 16 0 0 1 16 16"/>
+  <circle cx="5" cy="19" r="1"/>
+</svg>
+```
+
+- [ ] **Step 2: `src/components/ui/AppIcons.tsx` 수정 — rss 아이콘 등록**
+
+기존 파일:
+```tsx
+import GithubIcon from "@/assets/icons/icon-github.svg?react";
+import LinkedinIcon from "@/assets/icons/icon-linkedin.svg?react";
+
+const ICONS = {
+  sun: SunIcon,
+  moon: MoonIcon,
+  github: GithubIcon,
+  linkedin: LinkedinIcon,
+} as const;
+```
+
+변경 후:
+```tsx
+import GithubIcon from "@/assets/icons/icon-github.svg?react";
+import LinkedinIcon from "@/assets/icons/icon-linkedin.svg?react";
+import RssIcon from "@/assets/icons/icon-rss.svg?react";
+
+const ICONS = {
+  sun: SunIcon,
+  moon: MoonIcon,
+  github: GithubIcon,
+  linkedin: LinkedinIcon,
+  rss: RssIcon,
+} as const;
+```
+
+- [ ] **Step 3: 타입체크**
+
+```bash
+pnpm typecheck 2>&1 | tail -10
+```
+
+Expected: 오류 없음
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/assets/icons/icon-rss.svg src/components/ui/AppIcons.tsx
+git commit -m "feat(rss): add rss svg icon and register in AppIcons (#34)"
+git push origin feat/#34/rss-subscribe
+```
+
+---
+
+### Task 4: 헤더에 RSS 아이콘 링크 추가
+
+**Files:**
+- Modify: `src/components/Header.astro`
+
+- [ ] **Step 1: `src/components/Header.astro` 수정**
+
+LinkedIn NavLink 바로 뒤 (line 63 `</div>` 직전)에 추가:
+
+```astro
+<NavLink
+  href="/rss.xml"
+  target="_blank"
+  rel="noopener noreferrer"
+  aria-label="RSS 피드"
+  title="RSS 피드"
+  class="inline-flex size-8 items-center justify-center rounded-lg border-none bg-transparent text-gray-500 no-underline transition-colors duration-200 hover:bg-black/5 hover:text-[#F26522]! sm:size-9 dark:text-gray-400 dark:hover:bg-white/8 dark:hover:text-[#F26522]!"
+>
+  <AppIcon name="rss" className="size-4.5 sm:size-4.5" />
+</NavLink>
+```
+
+- [ ] **Step 2: 개발 서버 실행 후 헤더 확인**
+
+```bash
+pnpm dev
+```
+
+브라우저에서 `http://localhost:4321` 접속:
+- LinkedIn 아이콘 오른쪽에 RSS 아이콘 표시 확인
+- 호버 시 오렌지색(`#F26522`) 전환 확인
+- 다크 모드에서도 동일하게 작동 확인
+- 클릭 시 `/rss.xml` 새 탭에서 XML 표시 확인
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/Header.astro
+git commit -m "feat(rss): add rss icon link to header (#34)"
+git push origin feat/#34/rss-subscribe
+```
+
+---
+
+## Part B — seongmin36/seongmin36 (프로필 레포)
+
+> **사전 준비:** `seongmin36/seongmin36` 레포를 로컬에 클론하거나 이미 있는 경로로 이동한다.
+> ```bash
+> git clone https://github.com/seongmin36/seongmin36.git
+> cd seongmin36
+> ```
+
+---
+
+### Task 5: 블로그 카드 SVG 생성 스크립트
+
+**Files:**
+- Create: `scripts/generate-blog-card.mjs`
+
+- [ ] **Step 1: `scripts/` 디렉토리 확인**
+
+```bash
+ls scripts 2>/dev/null || mkdir scripts
+```
+
+- [ ] **Step 2: `scripts/generate-blog-card.mjs` 생성**
+
+```js
+#!/usr/bin/env node
+import { writeFileSync } from 'node:fs';
+
+const RSS_URL = 'https://blog.kronglog.dev/rss.xml';
+const OUTPUT_PATH = './recent-posts.svg';
+const MAX_POSTS = 3;
+const DESC_MAX = 60;
+
+function xmlEscape(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function extractTag(tag, xml) {
+  const cdata = new RegExp(
+    `<${tag}[^>]*><!\\[CDATA\\[([\\s\\S]*?)\\]\\]></${tag}>`,
+    'i'
+  ).exec(xml);
+  if (cdata) return cdata[1].trim();
+  const plain = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, 'i').exec(xml);
+  return plain ? plain[1].trim() : '';
+}
+
+function formatDate(dateStr) {
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return '';
+  return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function truncate(str, max) {
+  return str.length > max ? str.slice(0, max) + '…' : str;
+}
+
+async function fetchPosts() {
+  const res = await fetch(RSS_URL);
+  if (!res.ok) throw new Error(`RSS fetch failed: ${res.status} ${res.statusText}`);
+  const xml = await res.text();
+
+  return [...xml.matchAll(/<item>([\s\S]*?)<\/item>/g)]
+    .slice(0, MAX_POSTS)
+    .map((m) => {
+      const item = m[1];
+      return {
+        title: extractTag('title', item),
+        description: extractTag('description', item),
+        pubDate: extractTag('pubDate', item),
+      };
+    });
+}
+
+function generateSvg(posts) {
+  const W = 480;
+  const PAD = 20;
+  const HEADER_H = 52;
+  const POST_H = 68;
+  const FOOTER_PAD = 16;
+  const H = HEADER_H + posts.length * POST_H + FOOTER_PAD;
+
+  const rows = posts
+    .map((post, i) => {
+      const y = HEADER_H + i * POST_H;
+      const title = xmlEscape(truncate(post.title, 55));
+      const desc = post.description ? xmlEscape(truncate(post.description, DESC_MAX)) : '';
+      const date = xmlEscape(formatDate(post.pubDate));
+      return `
+  <text class="t" x="${PAD}" y="${y + 18}">› ${title}</text>
+  ${desc ? `<text class="d" x="${PAD}" y="${y + 36}">${desc}</text>` : ''}
+  <text class="dt" x="${PAD}" y="${y + 52}">${date}</text>`;
+    })
+    .join('');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
+  <style>
+    .bg { fill: #ffffff }
+    .dv { stroke: #e5e7eb; stroke-width: 1 }
+    .h  { fill: #374151; font: 600 14px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif }
+    .t  { fill: #111827; font: 700 13px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif }
+    .d  { fill: #6b7280; font: 400 12px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif }
+    .dt { fill: #9ca3af; font: 400 11px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif }
+    @media (prefers-color-scheme: dark) {
+      .bg { fill: #0d1117 }
+      .dv { stroke: #30363d }
+      .h  { fill: #c9d1d9 }
+      .t  { fill: #f0f6fc }
+      .d  { fill: #8b949e }
+      .dt { fill: #6e7681 }
+    }
+  </style>
+  <rect class="bg" width="${W}" height="${H}" rx="8"/>
+  <text class="h" x="${PAD}" y="30">📝 최근 블로그 글</text>
+  <line class="dv" x1="${PAD}" y1="42" x2="${W - PAD}" y2="42"/>
+  ${rows}
+</svg>`;
+}
+
+const posts = await fetchPosts();
+const svg = generateSvg(posts);
+writeFileSync(OUTPUT_PATH, svg, 'utf-8');
+console.log(`Generated ${OUTPUT_PATH} with ${posts.length} posts`);
+```
+
+- [ ] **Step 3: 로컬 실행으로 SVG 생성 확인**
+
+> **의존성 주의:** Part A(`feat/#34/rss-subscribe`)가 `main`에 머지·배포된 후 실행해야 `https://blog.kronglog.dev/rss.xml`이 유효하다.
+> 배포 전 로컬 테스트가 필요한 경우: kronglog 디렉토리에서 `pnpm dev` 실행 후 스크립트 상단 `RSS_URL`을 일시적으로 `http://localhost:4321/rss.xml`로 변경해 테스트한다 (커밋 전 원복).
+
+```bash
+node scripts/generate-blog-card.mjs
+```
+
+Expected:
+```
+Generated ./recent-posts.svg with 3 posts
+```
+
+- [ ] **Step 4: 생성된 SVG 내용 확인**
+
+```bash
+head -20 recent-posts.svg
+```
+
+Expected: `<svg xmlns=...`로 시작하는 유효한 SVG, 포스트 제목·날짜 포함
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add scripts/generate-blog-card.mjs recent-posts.svg
+git commit -m "feat: add blog card svg generation script"
+git push
+```
+
+---
+
+### Task 6: GitHub Action 워크플로우 추가
+
+**Files:**
+- Create: `.github/workflows/update-blog-card.yml`
+
+- [ ] **Step 1: `.github/workflows/` 디렉토리 확인**
+
+```bash
+mkdir -p .github/workflows
+```
+
+- [ ] **Step 2: `.github/workflows/update-blog-card.yml` 생성**
+
+```yaml
+name: Update Blog Card
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Generate blog card
+        run: node scripts/generate-blog-card.mjs
+
+      - name: Commit if changed
+        run: |
+          git diff --quiet && echo "No changes, skipping." && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add recent-posts.svg
+          git commit -m "chore: update recent-posts.svg"
+          git push
+```
+
+- [ ] **Step 3: 커밋 & 푸시**
+
+```bash
+git add .github/workflows/update-blog-card.yml
+git commit -m "feat: add github action to auto-update blog card"
+git push
+```
+
+- [ ] **Step 4: GitHub에서 수동 실행 확인**
+
+`https://github.com/seongmin36/seongmin36/actions` 접속 →
+"Update Blog Card" 워크플로우 → "Run workflow" 클릭 →
+실행 성공 및 `recent-posts.svg` 커밋 확인
+
+---
+
+### Task 7: README에 블로그 카드 삽입
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: README.md에 블로그 카드 섹션 추가**
+
+원하는 위치에 아래 마크다운 삽입:
+
+```markdown
+## 📝 최근 블로그 글
+
+[![Recent Posts](./recent-posts.svg)](https://blog.kronglog.dev/blogs)
+```
+
+SVG 전체를 `https://blog.kronglog.dev/blogs`로 링크해 클릭 가능하게 처리.
+
+- [ ] **Step 2: GitHub 프로필 페이지에서 카드 표시 확인**
+
+```bash
+git add README.md
+git commit -m "docs: add recent blog posts card to README"
+git push
+```
+
+`https://github.com/seongmin36` 접속 → 프로필 페이지에서 블로그 카드 표시 확인
+라이트/다크 모드 전환 시 SVG 색상 자동 변경 확인
+
+---
+
+## 완료 체크리스트
+
+- [ ] `https://blog.kronglog.dev/rss.xml` 유효한 RSS 2.0 XML 반환
+- [ ] 블로그 헤더에 RSS 아이콘 표시, 호버 오렌지 전환
+- [ ] GitHub 프로필에 최근 포스트 3개 SVG 카드 표시
+- [ ] 다크/라이트 모드 SVG 자동 전환
+- [ ] GitHub Action 스케줄(매 6시간) 정상 실행
+- [ ] `feat/#34/rss-subscribe` 브랜치 PR 생성 가능 상태

--- a/docs/superpowers/specs/2026-05-22-rss-feed-github-card-design.md
+++ b/docs/superpowers/specs/2026-05-22-rss-feed-github-card-design.md
@@ -1,0 +1,138 @@
+# RSS 피드 + GitHub 프로필 블로그 카드 설계
+
+**날짜:** 2026-05-22  
+**이슈:** seongmin36/krongLog#34  
+**브랜치:** feat/#34/rss-subscribe
+
+---
+
+## 1. 개요
+
+두 가지 기능을 구현한다:
+
+1. **RSS 피드** — `blog.kronglog.dev/rss.xml`을 정적으로 생성해 외부 RSS 리더 구독 지원
+2. **GitHub 프로필 블로그 카드** — GitHub Actions가 RSS를 읽어 SVG를 생성·커밋, `seongmin36/seongmin36` README에 최근 포스트 3개를 표시
+
+---
+
+## 2. 아키텍처
+
+```
+[seongmin36/krongLog — feat/#34/rss-subscribe]
+  src/pages/rss.xml.ts          ← RSS 엔드포인트 (정적 빌드)
+  src/assets/icons/icon-rss.svg ← RSS 아이콘 SVG
+  src/components/ui/AppIcons.tsx ← rss 아이콘 등록
+  src/components/Header.astro   ← RSS 아이콘 링크 추가
+
+[seongmin36/seongmin36 — 프로필 레포]
+  scripts/generate-blog-card.mjs          ← RSS fetch → SVG 생성
+  .github/workflows/update-blog-card.yml  ← 스케줄 + 수동 트리거
+  recent-posts.svg                        ← 자동 생성 결과물
+  README.md                               ← ![](./recent-posts.svg) 삽입
+```
+
+---
+
+## 3. kronglog — RSS 피드
+
+### 3-1. 패키지
+
+```
+@astrojs/rss
+```
+
+`astro.config.mjs` 변경 없음 (integration이 아닌 helper 함수).
+
+### 3-2. `src/pages/rss.xml.ts`
+
+- `GET` 핸들러로 Astro RSS XML 반환
+- 포함 필드: `title`, `pubDate`(=`date`), `description`(없으면 빈 문자열), `link`(`/blogs/${post.id}`)
+- 날짜 내림차순 정렬, 전체 포스트 포함
+- feed 메타: `title: "Krong Dev."`, `description: "개발하면서 배운 것들을 기록합니다."`, `site: "https://blog.kronglog.dev"`
+
+### 3-3. 헤더 RSS 아이콘
+
+| 항목 | 내용 |
+|------|------|
+| `src/assets/icons/icon-rss.svg` | 표준 RSS 웨이브 SVG (24×24, currentColor) |
+| `src/components/ui/AppIcons.tsx` | `rss: RssIcon` 추가 |
+| `src/components/Header.astro` | LinkedIn 옆에 NavLink 추가, `href="/rss.xml"`, `target="_blank"` |
+
+호버 색상: `#F26522` (RSS 표준 오렌지, LinkedIn `#0A66C2` 패턴과 동일하게 적용).
+
+---
+
+## 4. seongmin36/seongmin36 — 블로그 카드
+
+### 4-1. `scripts/generate-blog-card.mjs`
+
+- 외부 의존성 없음 (Node 22 내장 `fetch`, `DOMParser` 없이 정규식 기반 XML 파싱)
+- 최신 3개 포스트 추출: `title`, `description`(60자 truncate + `…`), `pubDate`, `link`
+- SVG 출력 스펙:
+  - 너비 480px, 높이 동적 계산
+  - 내장 `<style>`에 `prefers-color-scheme: dark` 미디어쿼리로 다크/라이트 자동 전환
+  - 라이트: 흰 배경 + 어두운 텍스트 / 다크: 어두운 배경 + 밝은 텍스트
+  - 포스트당: 제목(볼드) + 설명(그레이) + 날짜(소형)
+  - SVG `<a>` 태그 미사용 (GitHub 보안 정책상 무시됨)
+- `recent-posts.svg`로 파일 write
+
+### 4-2. `.github/workflows/update-blog-card.yml`
+
+```yaml
+트리거:
+  - schedule: '0 */6 * * *'   # 매 6시간
+  - workflow_dispatch          # 수동 실행
+
+steps:
+  1. actions/checkout
+  2. actions/setup-node@v4 (node-version: '22')
+  3. node scripts/generate-blog-card.mjs
+  4. git diff --quiet && exit 0  # 변경 없으면 스킵
+  5. git config user 설정 (github-actions[bot])
+  6. git commit -m "chore: update recent-posts.svg"
+  7. git push
+```
+
+### 4-3. `README.md`
+
+```markdown
+## 📝 최근 블로그 글
+
+[![Recent Posts](./recent-posts.svg)](https://blog.kronglog.dev/blogs)
+```
+
+SVG 전체를 블로그 목록으로 링크 걸어 클릭 가능하게 처리.
+
+---
+
+## 5. 에러 핸들링 & 엣지케이스
+
+| 상황 | 처리 |
+|------|------|
+| RSS fetch 실패 | non-zero exit → Action 실패 표시, SVG 덮어쓰기 않음 |
+| description 없는 포스트 | 빈 줄로 처리 |
+| 포스트 3개 미만 | 있는 것만 표시 |
+| SVG 내 특수문자 (`<`, `>`, `&`) | XML escape |
+| 변경 없을 때 | `git diff --quiet` 체크 후 커밋 스킵 |
+
+---
+
+## 6. 커밋 전략
+
+| 레포 | 커밋 단위 | 포맷 예시 |
+|------|-----------|-----------|
+| kronglog | RSS 엔드포인트 | `feat(rss): add rss feed endpoint (#34)` |
+| kronglog | 헤더 RSS 아이콘 | `feat(rss): add rss icon to header (#34)` |
+| seongmin36/seongmin36 | 블로그 카드 스크립트 + Action | `feat: add blog card auto-update workflow` |
+| seongmin36/seongmin36 | README 업데이트 | `docs: add recent blog posts card to README` |
+
+---
+
+## 7. 테스트 체크리스트
+
+- [ ] `pnpm build` 후 `dist/rss.xml` 존재 확인
+- [ ] `dist/rss.xml` 유효 XML 파싱 가능
+- [ ] 헤더 RSS 아이콘 라이트/다크 모드 호버 색상 확인
+- [ ] `node scripts/generate-blog-card.mjs` 로컬 실행 → SVG 생성 확인
+- [ ] SVG 다크/라이트 모드 브라우저 확인
+- [ ] `workflow_dispatch`로 수동 Action 실행 → 커밋 확인

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
     "@astrojs/react": "^5.0.2",
+    "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
     "@astrojs/vercel": "^10.0.4",
     "@nanostores/react": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@astrojs/react':
         specifier: ^5.0.2
         version: 5.0.2(@types/node@24.12.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(yaml@2.8.3)
+      '@astrojs/rss':
+        specifier: ^4.0.18
+        version: 4.0.18
       '@astrojs/sitemap':
         specifier: ^3.7.2
         version: 3.7.2
@@ -135,6 +138,9 @@ packages:
       '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
       react: ^17.0.2 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+
+  '@astrojs/rss@4.0.18':
+    resolution: {integrity: sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==}
 
   '@astrojs/sitemap@3.7.2':
     resolution: {integrity: sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==}
@@ -614,6 +620,9 @@ packages:
     peerDependencies:
       nanostores: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^1.0.0
       react: '>=18.0.0'
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -1508,6 +1517,13 @@ packages:
   fast-wrap-ansi@0.1.6:
     resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.8.0:
+    resolution: {integrity: sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==}
+    hasBin: true
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2089,6 +2105,10 @@ packages:
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
@@ -2393,6 +2413,9 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -2766,6 +2789,10 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
 
@@ -2936,6 +2963,12 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  '@astrojs/rss@4.0.18':
+    dependencies:
+      fast-xml-parser: 5.8.0
+      piccolore: 0.1.3
+      zod: 4.3.6
 
   '@astrojs/sitemap@3.7.2':
     dependencies:
@@ -3384,6 +3417,8 @@ snapshots:
     dependencies:
       nanostores: 1.1.1
       react: 19.2.4
+
+  '@nodable/entities@2.1.0': {}
 
   '@oslojs/encoding@1.1.0': {}
 
@@ -4300,6 +4335,19 @@ snapshots:
     dependencies:
       fast-string-width: 1.1.0
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.8.0:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
+      xml-naming: 0.1.0
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
@@ -5185,6 +5233,8 @@ snapshots:
 
   path-browserify@1.0.1: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.2.6
@@ -5536,6 +5586,8 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strnum@2.3.0: {}
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -5859,6 +5911,8 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  xml-naming@0.1.0: {}
 
   xxhash-wasm@1.1.0: {}
 

--- a/src/assets/icons/icon-rss.svg
+++ b/src/assets/icons/icon-rss.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 11a9 9 0 0 1 9 9"/>
+  <path d="M4 4a16 16 0 0 1 16 16"/>
+  <circle cx="5" cy="19" r="1"/>
+</svg>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -69,6 +69,17 @@ const NAV_ITEMS = [
         >
           <AppIcon name="linkedin" className="size-4.5 sm:size-6" />
         </NavLink>
+
+        <NavLink
+          href="/rss.xml"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="RSS 피드"
+          title="RSS 피드"
+          class="inline-flex size-8 items-center justify-center rounded-lg border-none bg-transparent text-gray-500 no-underline transition-colors duration-200 hover:bg-black/5 hover:text-[#F26522]! sm:size-9 dark:text-gray-400 dark:hover:bg-white/8 dark:hover:text-[#F26522]!"
+        >
+          <AppIcon name="rss" className="size-4.5 sm:size-4.5" />
+        </NavLink>
       </div>
     </nav>
   </div>

--- a/src/components/ui/AppIcons.tsx
+++ b/src/components/ui/AppIcons.tsx
@@ -3,12 +3,14 @@ import SunIcon from "@/assets/icons/icon-sun.svg?react";
 import MoonIcon from "@/assets/icons/icon-moon.svg?react";
 import GithubIcon from "@/assets/icons/icon-github.svg?react";
 import LinkedinIcon from "@/assets/icons/icon-linkedin.svg?react";
+import RssIcon from "@/assets/icons/icon-rss.svg?react";
 
 const ICONS = {
   sun: SunIcon,
   moon: MoonIcon,
   github: GithubIcon,
   linkedin: LinkedinIcon,
+  rss: RssIcon,
 } as const;
 
 type IconName = keyof typeof ICONS;

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,22 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import type { APIContext } from 'astro';
+
+export async function GET(context: APIContext) {
+  const posts = await getCollection('post');
+  const sorted = posts.sort(
+    (a, b) => b.data.date.getTime() - a.data.date.getTime()
+  );
+
+  return rss({
+    title: 'Krong Dev.',
+    description: '개발하면서 배운 것들을 기록합니다.',
+    site: context.site!,
+    items: sorted.map((post) => ({
+      title: post.data.title,
+      pubDate: post.data.date,
+      description: post.data.description ?? '',
+      link: `/blogs/${post.id}`,
+    })),
+  });
+}


### PR DESCRIPTION
## 연관 이슈

closes #34

---

## PR 유형

- [ ] ✍️ 새 글 작성
- [ ] 🔧 기존 글 수정
- [ ] ➕ 내용 보완
- [ ] 🗑️ 글 삭제 / 비공개 처리

---

## 변경 내용 요약

RSS 피드 엔드포인트와 헤더 RSS 아이콘을 추가합니다.

- `src/pages/rss.xml.ts`: `@astrojs/rss`로 RSS 2.0 엔드포인트 생성 (빌드 시 `/rss.xml` 정적 파일 출력)
- `src/assets/icons/icon-rss.svg`: RSS 웨이브 아이콘 추가 (currentColor, 24×24)
- `src/components/ui/AppIcons.tsx`: `rss` 아이콘 등록
- `src/components/Header.astro`: LinkedIn 옆 RSS 아이콘 링크 추가, 호버 시 오렌지(#F26522) 전환

---

## 작성 시 고려한 점 (선택)

- 라이트/다크 모드 모두 동일한 호버 색상(`#F26522`) 적용
- 기존 GitHub/LinkedIn 아이콘과 동일한 `NavLink` 패턴 사용
- SVG는 `currentColor`로 CSS 컬러 상속, SVGR(`?react`)로 import

---

## 머지 전 체크리스트

- [x] 맞춤법 / 오탈자를 검토했습니다.
- [x] 코드 예시가 있다면 실제로 동작하는지 확인했습니다.
- [x] 외부 링크가 있다면 유효한지 확인했습니다.
- [x] 글의 제목, 슬러그, 날짜 메타데이터가 올바르게 작성되었습니다.