### PR TITLE
ci: main push 시 프로필 SVG 자동 업데이트 트리거

### DIFF
--- a/.github/workflows/notify-profile.yml
+++ b/.github/workflows/notify-profile.yml
@@ -1,0 +1,16 @@
+name: Notify Profile
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger profile SVG update
+        run: |
+          gh workflow run update-blog-card.yml \
+            --repo seongmin36/seongmin36
+        env:
+          GH_TOKEN: ${{ secrets.PROFILE_REPO_TOKEN }}


### PR DESCRIPTION
## Summary
- `krongLog` main 브랜치에 push 시 `seongmin36/seongmin36`의 `update-blog-card.yml` 워크플로우를 즉시 트리거
- 기존 6시간 스케줄 방식 → CI 이벤트 기반으로 전환 (스케줄은 프로필 레포에서 제거 완료)
- `PROFILE_REPO_TOKEN` secret 사용 (krongLog 레포에 등록 완료)

## Test plan
- [ ] main merge 후 `seongmin36/seongmin36` Actions 탭에서 `Update Blog Card` 워크플로우 자동 실행 확인
- [ ] `recent-posts.svg` 최신 글 3개로 업데이트 확인