### PR TITLE
ci: Vercel 배포 대기 3분 후 프로필 SVG 트리거

### DIFF
--- a/.github/workflows/notify-profile.yml
+++ b/.github/workflows/notify-profile.yml
@@ -8,6 +8,9 @@ jobs:
   trigger:
     runs-on: ubuntu-latest
     steps:
+      - name: Wait for Vercel deployment
+        run: sleep 180
+
       - name: Trigger profile SVG update
         run: |
           gh workflow run update-blog-card.yml \


### PR DESCRIPTION
## Summary
- push 직후 RSS를 읽으면 Vercel 배포 전이라 SVG가 갱신되지 않는 문제 수정
- `notify-profile.yml`에 3분(180s) 대기 추가 후 프로필 워크플로우 트리거

## Test plan
- [ ] main push 후 3분 뒤 `seongmin36/seongmin36` Actions에서 `Update Blog Card` 실행 확인
- [ ] `recent-posts.svg` 최신 글로 업데이트 확인