### PR TITLE
feat: 맥 스타일 코드 블록 (lang탭·copy버튼·라인넘버)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run type check
+        run: pnpm typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.32.1
+          version: latest
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
+        run: pnpm install --frozen-lockfile
 
       - name: Run type check
         run: pnpm typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10.32.1
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Run type check
         run: pnpm typecheck

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ pnpm typecheck    # astro check (Astro + TypeScript 진단)
 **주요 아키텍처 결정 사항:**
 - React는 클라이언트 사이드 인터랙션이 필요한 컴포넌트(`ThemeToggle.tsx`, `AppIcons.tsx`)에만 사용됩니다. 나머지 컴포넌트는 모두 `.astro` 파일입니다.
 - 다크 모드 상태는 Nanostores(`src/lib/stores/theme.ts`)로 관리되며 localStorage에 저장됩니다. `BaseLayout.astro`에 FOUC 방지를 위한 인라인 스크립트가 포함되어 있습니다.
-- Tailwind v4 설정은 `src/styles/global.css`에 완전히 위치합니다(`tailwind.config.*` 파일 없음). 커스텀 테마 토큰(색상, 폰트)은 `@theme inline`으로 정의됩니다.
+- Tailwind v4 설정은 `src/styles/global.css`에 완전히 위치합니다(`tailwind.config.*` 파일 없음). 커스텀 테마 토큰(색상, 폰트)은 `@theme`으로 정의하며, 규칙은 `docs/code-conventions.md`를 참고합니다.
 - 기술 태그 색상(React, TypeScript, Docker 등)은 `Tag.astro`의 `data-tag` 속성을 통한 CSS로 정의됩니다.
 - 경로 별칭 `@/*`는 `src/*`로 매핑됩니다.
 - SVG 파일은 SVGR(Vite 플러그인, `astro.config.mjs`)을 통해 React 컴포넌트로 임포트됩니다.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
 import vercel from "@astrojs/vercel";
 import svgr from "vite-plugin-svgr";
+import { visit } from "unist-util-visit";
 import {
   transformerMetaHighlight,
   transformerMetaWordHighlight,
@@ -13,6 +14,100 @@ import {
   transformerNotationFocus,
   transformerNotationHighlight,
 } from "@shikijs/transformers";
+
+function transformerCodeBlock() {
+  return {
+    name: "code-block-mac",
+    pre(node) {
+      const lang = this.options.lang ?? "";
+      if (lang) node.properties["data-lang"] = lang;
+    },
+  };
+}
+
+// rehype 플러그인: 래퍼 div + 언어탭 + copy 버튼 주입
+function rehypeCodeBlock() {
+  return (tree) => {
+    visit(tree, "element", (node, index, parent) => {
+      if (node.tagName !== "pre" || !parent || index == null) return;
+      const lang = node.properties?.["data-lang"] ?? "";
+      const langTab = lang
+        ? {
+            type: "element",
+            tagName: "span",
+            properties: { className: ["code-block-lang"] },
+            children: [{ type: "text", value: lang }],
+          }
+        : null;
+      const copyBtn = {
+        type: "element",
+        tagName: "button",
+        properties: { className: ["copy-btn"], "aria-label": "코드 복사" },
+        children: [
+          {
+            type: "element",
+            tagName: "svg",
+            properties: {
+              xmlns: "http://www.w3.org/2000/svg",
+              width: "14",
+              height: "14",
+              viewBox: "0 0 24 24",
+              fill: "none",
+              stroke: "currentColor",
+              "stroke-width": "2",
+              "stroke-linecap": "round",
+              "stroke-linejoin": "round",
+              "aria-hidden": "true",
+            },
+            children: [
+              {
+                type: "element",
+                tagName: "rect",
+                properties: {
+                  x: "9",
+                  y: "9",
+                  width: "13",
+                  height: "13",
+                  rx: "2",
+                  ry: "2",
+                },
+                children: [],
+              },
+              {
+                type: "element",
+                tagName: "path",
+                properties: {
+                  d: "M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1",
+                },
+                children: [],
+              },
+            ],
+          },
+        ],
+      };
+      const header = langTab
+        ? {
+            type: "element",
+            tagName: "div",
+            properties: { className: ["code-block-header"] },
+            children: [langTab],
+          }
+        : null;
+      const body = {
+        type: "element",
+        tagName: "div",
+        properties: { className: ["code-block-body"] },
+        children: [node, copyBtn],
+      };
+      parent.children[index] = {
+        type: "element",
+        tagName: "div",
+        properties: { className: ["code-block-wrapper"] },
+        children: header ? [header, body] : [body],
+      };
+    });
+  };
+}
 
 export default defineConfig({
   output: "static",
@@ -67,8 +162,10 @@ export default defineConfig({
         transformerNotationErrorLevel(),
         transformerNotationFocus(),
         transformerNotationHighlight(),
+        transformerCodeBlock(),
       ],
     },
+    rehypePlugins: [rehypeCodeBlock],
   },
 
   vite: {

--- a/docs/code-conventions.md
+++ b/docs/code-conventions.md
@@ -1,0 +1,120 @@
+# 코드 컨벤션 — 스타일 토큰
+
+색상·테마 값은 **`src/styles/global.css`의 `@theme` 블록**에서만 정의합니다.<br />
+`mdx.css`, 컴포넌트, MDX 본문에서는 **hex / rgb / rgba 리터럴을 쓰지 않고** 토큰(`var(--color-…)` 또는 Tailwind 유틸)만 사용합니다.
+
+## 규칙
+
+1. **새 색이 필요하면** `global.css`에 역할(role) 이름으로 토큰을 추가한 뒤 사용합니다.
+2. **기존 토큰이 있으면** 새 이름을 만들지 않고 재사용합니다.
+3. **다크 모드**는 `-dark` 접미사 토큰 또는 `.dark` 선택자 + 다크 전용 토큰으로 처리합니다.
+4. **브랜드/기술 태그** 색은 `--color-tag-{name}-*` 패밀리를 유지합니다.
+5. **Shiki 코드 블록** 배경은 github-light/dark와 맞춘 `--color-code-block-surface*` 를 사용합니다. Shiki 인라인 `style`은 빌드 산출물이며, 시각적 덮어쓰기는 CSS 토큰으로 합니다.
+
+## 네이밍
+
+| 패턴 | 용도 | 예 |
+|------|------|-----|
+| `--color-{role}` | 라이트 기본 | `--color-primary`, `--color-description` |
+| `--color-{role}-dark` | 다크 전용 | `--color-dark-description`, `--color-code-block-surface-dark` |
+| `--color-tag-{brand}-*` | 기술 태그 | `--color-tag-react-bg` |
+| `--color-brand-*` | 외부 서비스 브랜드 | `--color-brand-linkedin` |
+| `--color-hover-overlay-*` | hover 배경 오버레이 | `--color-hover-overlay-light` |
+
+## 토큰 목록 (`global.css`)
+
+### 브랜드 · 본문
+
+| 토큰 | 값 | 용도 |
+|------|-----|------|
+| `--color-primary` | `#3b7a57` | 링크, 강조, 인라인 코드(라이트) |
+| `--color-description` | `#4b5563` | 본문 보조, 코드 블록 border(라이트) |
+| `--color-dark` | `#1b1b1b` | 다크 배경, 테이블 헤더(라이트) |
+| `--color-dark-text` | `#f0a8b8` | 다크 모드 강조 텍스트 |
+| `--color-dark-description` | `#d1d5db` | 다크 본문 보조, 코드 블록 border(다크) |
+
+### UI 보조
+
+| 토큰 | 값 | 용도 |
+|------|-----|------|
+| `--color-muted` | `#9ca3af` | copy 버튼, 라인 넘버(라이트) |
+| `--color-muted-dark` | `#6b7280` | copy 버튼·라인 넘버(다크) |
+| `--color-success` | `#16a34a` | copy 성공(라이트) |
+| `--color-success-dark` | `#4ade80` | copy 성공(다크) |
+| `--color-hover-overlay-light` | `rgba(0,0,0,0.06)` | 버튼 hover 배경(라이트) |
+| `--color-hover-overlay-dark` | `rgba(255,255,255,0.08)` | 버튼 hover 배경(다크) |
+
+### MDX · 코드
+
+| 토큰 | 값 | 용도 |
+|------|-----|------|
+| `--color-highlight-pen` | `#e9f1ec` | `<mark>`, Shiki 줄/단어 하이라이트(라이트) |
+| `--color-highlight-pen-dark` | `#7a5b69` | 동일(다크) |
+| `--color-code-block-surface` | `#f6f8fa` | 코드 블록·lang 탭 배경(라이트) |
+| `--color-code-block-surface-dark` | `#24292e` | 코드 블록·lang 탭 배경(다크) |
+| `--color-inline-code-surface` | `#f3f4f6` | 인라인 `` `code` `` · 기본 태그 배경(라이트) |
+| `--color-inline-code-surface-dark` | `#2a2d35` | 인라인 `` `code` `` 배경(다크) |
+| `--color-blockquote-surface` | `#f8fafc` | 인용구 배경(라이트) |
+| `--color-blockquote-surface-dark` | `#1a1b1e` | 인용구 배경(다크) |
+| `--color-blockquote-text-dark` | `#9ca3af` | 인용구 텍스트(다크) |
+| `--color-tag-default-bg-dark` | `#383b40` | 기본 태그 배경(다크) |
+| `--color-tag-default-text-dark` | `#9ca3af` | 기본 태그 텍스트(다크) |
+
+라이트 모드 기본 태그는 `--color-inline-code-surface` + `--color-description` 조합을 재사용합니다.
+
+### Tooltip · 소셜
+
+| 토큰 | 용도 |
+|------|------|
+| `--tootip-light`, `--tootip-light-text` | Tooltip(라이트) |
+| `--tootip-dark`, `--tootip-dark-text` | Tooltip(다크) |
+| `--color-brand-linkedin` | LinkedIn 아이콘 hover |
+| `--color-brand-rss` | RSS 아이콘 hover |
+
+기술 태그(`--color-tag-react-*` 등) 전체 목록은 `global.css` `@theme` 블록을 참고합니다.
+
+## 사용 예
+
+```css
+/* CSS (mdx.css 등) */
+.copy-btn {
+  color: var(--color-muted);
+}
+.dark .copy-btn:hover {
+  color: var(--color-dark-description);
+  background-color: var(--color-hover-overlay-dark);
+}
+```
+
+```html
+<!-- Tailwind: @theme에 등록된 --color-* 는 text-*, bg-* 유틸로도 사용 가능 -->
+<p class="text-description dark:text-dark-description">...</p>
+```
+
+## 로컬 alias (예외)
+
+코드 블록처럼 **한 컴포넌트 묶음**에서 같은 토큰을 여러 선택자가 쓰면, 래퍼에 alias만 허용합니다.
+
+```css
+.code-block-wrapper {
+  --code-block-border: var(--color-description);
+  --code-block-surface: var(--color-code-block-surface);
+}
+.dark .code-block-wrapper {
+  --code-block-border: var(--color-dark-description);
+  --code-block-surface: var(--color-code-block-surface-dark);
+}
+```
+
+alias 값은 **반드시 global 토큰을 참조**하고, hex를 직접 넣지 않습니다.
+
+## 금지 · 허용
+
+| 금지 | 허용 |
+|------|------|
+| `color: #9ca3af` | `color: var(--color-muted)` |
+| `dark:bg-[#2a2d35]` | `dark:bg-[var(--color-inline-code-surface-dark)]` |
+| `@apply … dark:bg-[#383B40]` | `background-color: var(--color-tag-default-bg-dark)` |
+| MDX 본문에 임의 hex (특수 하이라이트 제외) | `<mark>` + CSS 토큰 |
+
+MDX 본문 일회성 색(`study-nodejs-4th` JWT `<mark style="…">` 등)은 콘텐츠 예외로 두고, UI·테마는 토큰만 사용합니다.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "prettier-plugin-astro": "0.14.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "typescript": "^6.0.2",
+    "unist-util-visit": "^5.1.0",
     "vite-plugin-svgr": "^4.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,10 +42,5 @@
     "prettier-plugin-tailwindcss": "^0.7.2",
     "typescript": "^6.0.2",
     "vite-plugin-svgr": "^4.5.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "vite": "^7"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
       vite-plugin-svgr:
         specifier: ^4.5.0
         version: 4.5.0(rollup@4.58.0)(typescript@6.0.2)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.3))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,9 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+  onlyBuiltDependencies:
+    - esbuild
+    - sharp
 
 overrides:
   vite: ^7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,9 +3,6 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
-  onlyBuiltDependencies:
-    - esbuild
-    - sharp
 
 overrides:
   vite: ^7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+overrides:
+  vite: "^7"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
 overrides:
   vite: "^7"
+
+onlyBuiltDependencies:
+  - esbuild
+  - sharp

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 overrides:
   vite: "^7"
 
-onlyBuiltDependencies:
-  - esbuild
-  - sharp
+allowBuilds:
+  esbuild: true
+  sharp: true

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -65,7 +65,7 @@ const NAV_ITEMS = [
           target="_blank"
           rel="noopener noreferrer"
           aria-label="LinkedIn"
-          class="inline-flex size-8 items-center justify-center rounded-lg border-none bg-transparent text-gray-500 no-underline transition-colors duration-200 hover:bg-black/5 hover:text-[#0A66C2]! sm:size-9 dark:text-gray-400 dark:hover:bg-white/8 dark:hover:text-[#0A66C2]!"
+          class="hover:text-brand-linkedin! inline-flex size-8 items-center justify-center rounded-lg border-none bg-transparent text-gray-500 no-underline transition-colors duration-200 hover:bg-black/5 sm:size-9 dark:text-gray-400 dark:hover:bg-white/8 dark:hover:text-[var(--color-brand-linkedin)]!"
         >
           <AppIcon name="linkedin" className="size-4.5 sm:size-6" />
         </NavLink>
@@ -76,7 +76,7 @@ const NAV_ITEMS = [
           rel="noopener noreferrer"
           aria-label="RSS 피드"
           title="RSS 피드"
-          class="inline-flex size-8 items-center justify-center rounded-lg border-none bg-transparent text-gray-500 no-underline transition-colors duration-200 hover:bg-black/5 hover:text-[#F26522]! sm:size-9 dark:text-gray-400 dark:hover:bg-white/8 dark:hover:text-[#F26522]!"
+          class="hover:text-brand-rss! inline-flex size-8 items-center justify-center rounded-lg border-none bg-transparent text-gray-500 no-underline transition-colors duration-200 hover:bg-black/5 sm:size-9 dark:text-gray-400 dark:hover:bg-white/8 dark:hover:text-[var(--color-brand-rss)]!"
         >
           <AppIcon name="rss" className="size-4.5 sm:size-4.5" />
         </NavLink>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -65,7 +65,7 @@ const NAV_ITEMS = [
           target="_blank"
           rel="noopener noreferrer"
           aria-label="LinkedIn"
-          class="hover:text-brand-linkedin! inline-flex size-8 items-center justify-center rounded-lg border-none bg-transparent text-gray-500 no-underline transition-colors duration-200 hover:bg-black/5 sm:size-9 dark:text-gray-400 dark:hover:bg-white/8 dark:hover:text-[var(--color-brand-linkedin)]!"
+          class="hover:text-brand-linkedin! dark:hover:text-brand-linkedin! inline-flex size-8 items-center justify-center rounded-lg border-none bg-transparent text-gray-500 no-underline transition-colors duration-200 hover:bg-black/5 sm:size-9 dark:text-gray-400 dark:hover:bg-white/8"
         >
           <AppIcon name="linkedin" className="size-4.5 sm:size-6" />
         </NavLink>
@@ -76,7 +76,7 @@ const NAV_ITEMS = [
           rel="noopener noreferrer"
           aria-label="RSS 피드"
           title="RSS 피드"
-          class="hover:text-brand-rss! inline-flex size-8 items-center justify-center rounded-lg border-none bg-transparent text-gray-500 no-underline transition-colors duration-200 hover:bg-black/5 sm:size-9 dark:text-gray-400 dark:hover:bg-white/8 dark:hover:text-[var(--color-brand-rss)]!"
+          class="hover:text-brand-rss! dark:hover:text-brand-rss! inline-flex size-8 items-center justify-center rounded-lg border-none bg-transparent text-gray-500 no-underline transition-colors duration-200 hover:bg-black/5 sm:size-9 dark:text-gray-400 dark:hover:bg-white/8"
         >
           <AppIcon name="rss" className="size-4.5 sm:size-4.5" />
         </NavLink>

--- a/src/components/ui/CodeBlock.astro
+++ b/src/components/ui/CodeBlock.astro
@@ -1,0 +1,35 @@
+---
+// 코드 블록 Copy 버튼 동작 처리
+// Shiki transformer가 주입한 .code-block-wrapper 구조에 의존
+---
+
+<script>
+  const ICON_COPY = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>`;
+  const ICON_CHECK = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>`;
+
+  document.querySelectorAll<HTMLButtonElement>(".copy-btn").forEach((btn) => {
+    const pre = btn.closest(".code-block-wrapper")?.querySelector("pre");
+    if (!pre) return;
+
+    let resetTimer: ReturnType<typeof setTimeout> | undefined;
+
+    btn.addEventListener("click", async () => {
+      try {
+        await navigator.clipboard.writeText(pre.innerText);
+        clearTimeout(resetTimer);
+        btn.innerHTML = ICON_CHECK + '<span class="copy-label">Copied</span>';
+        btn.classList.add("copied");
+        resetTimer = setTimeout(() => {
+          // 먼저 .copied 제거 → color/opacity transition 시작
+          btn.classList.remove("copied");
+          // transition(150ms) 완료 후 아이콘 교체 → 번쩍 방지
+          setTimeout(() => {
+            btn.innerHTML = ICON_COPY;
+          }, 160);
+        }, 1500);
+      } catch {
+        // clipboard 미지원 환경 무시
+      }
+    });
+  });
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import Header from "@/components/Header.astro";
+import CodeBlock from "@/components/ui/CodeBlock.astro";
 import fontsCss from "@/styles/fonts.css?raw";
 import "@/styles/global.css";
 import {
@@ -145,4 +146,5 @@ const jsonLd =
       <slot />
     </main>
   </body>
+  <CodeBlock />
 </html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,6 +14,31 @@
   --color-dark-text: #f0a8b8;
   --color-dark-description: #d1d5db;
 
+  /* UI · 본문 보조 */
+  --color-muted: #9ca3af;
+  --color-muted-dark: #6b7280;
+  --color-success: #16a34a;
+  --color-success-dark: #4ade80;
+  --color-hover-overlay-light: rgba(0, 0, 0, 0.06);
+  --color-hover-overlay-dark: rgba(255, 255, 255, 0.08);
+
+  /* MDX · 코드 블록 (Shiki github-light / github-dark 배경) */
+  --color-code-block-surface: #f6f8fa;
+  --color-code-block-surface-dark: #24292e;
+
+  /* MDX · 인라인 코드 · 인용구 · 태그 기본 */
+  --color-inline-code-surface: #f3f4f6;
+  --color-inline-code-surface-dark: #2a2d35;
+  --color-blockquote-surface: #f8fafc;
+  --color-blockquote-surface-dark: #1a1b1e;
+  --color-blockquote-text-dark: #9ca3af;
+  --color-tag-default-bg-dark: #383b40;
+  --color-tag-default-text-dark: #9ca3af;
+
+  /* 소셜 · 브랜드 (Header 아이콘 hover) */
+  --color-brand-linkedin: #0a66c2;
+  --color-brand-rss: #f26522;
+
   /* 본문·코드 형광펜 하이라이트 (#E9F1EC 계열) */
   --color-highlight-pen: #e9f1ec;
   --color-highlight-pen-dark: #7a5b69;

--- a/src/styles/mdx.css
+++ b/src/styles/mdx.css
@@ -18,10 +18,6 @@
     @apply text-dark leading-relaxed;
   }
 
-  & pre {
-    @apply border border-gray-200 bg-transparent text-inherit;
-  }
-
   & hr {
     @apply border-gray-300;
   }
@@ -40,9 +36,7 @@
   & p {
     @apply text-gray-300;
   }
-  & pre {
-    @apply border-gray-800;
-  }
+
   & hr {
     @apply border-gray-600;
   }
@@ -70,8 +64,9 @@
 
 /* 인용구 */
 .prose blockquote {
-  @apply border-l-4 bg-slate-50 px-4 py-1 dark:bg-[#1a1b1e];
+  @apply border-l-4 px-4 py-1;
   border-left-color: var(--color-primary);
+  background-color: var(--color-blockquote-surface);
 }
 
 .prose blockquote p {
@@ -79,8 +74,9 @@
 }
 
 .dark .prose blockquote {
-  color: #9ca3af;
+  color: var(--color-blockquote-text-dark);
   border-left-color: var(--color-dark-text);
+  background-color: var(--color-blockquote-surface-dark);
 }
 
 /* 링크: hover 시에만 underline */
@@ -118,37 +114,35 @@
 }
 
 /* Shiki: 줄 단위 / 단어 단위 하이라이트 */
-.astro-code .line.highlighted,
-.shiki .line.highlighted {
+.prose-blog .code-block-wrapper pre.astro-code .line.highlighted {
   background-color: var(--color-highlight-pen) !important;
   border-radius: 0.1875rem;
 }
 
-.dark .astro-code .line.highlighted,
-.dark .shiki .line.highlighted {
+.dark .prose-blog .code-block-wrapper pre.astro-code .line.highlighted {
   background-color: var(--color-highlight-pen-dark) !important;
 }
 
-.astro-code .highlighted-word,
-.shiki .highlighted-word {
+.prose-blog .code-block-wrapper pre.astro-code .highlighted-word {
   background-color: var(--color-highlight-pen) !important;
   border-radius: 0.125rem;
   padding-block: 0.05em;
 }
 
-.dark .astro-code .highlighted-word,
-.dark .shiki .highlighted-word {
+.dark .prose-blog .code-block-wrapper pre.astro-code .highlighted-word {
   background-color: var(--color-highlight-pen-dark) !important;
 }
 
 /* 인라인 코드 스타일 */
 .prose :not(pre) > code {
-  @apply rounded bg-gray-100 px-1.5 py-0.5 text-sm font-bold dark:bg-[#2a2d35];
+  @apply rounded px-1.5 py-0.5 text-sm font-bold;
+  background-color: var(--color-inline-code-surface);
   color: var(--color-primary);
 }
 
 .dark .prose :not(pre) > code {
   color: var(--color-dark-text);
+  background-color: var(--color-inline-code-surface-dark);
 }
 
 /* backtick(`) 제거 */
@@ -157,29 +151,139 @@
   content: "" !important;
 }
 
-/* Shiki 코드 블록 스타일 */
-.astro-code {
-  --shiki-light-bg: #f6f8fa !important;
+.code-block-wrapper {
+  @apply my-6;
+  --code-block-border: #e5e7eb;
+  --code-block-surface: var(--color-code-block-surface);
+}
+
+.dark .code-block-wrapper {
+  --code-block-border: #374151;
+  --code-block-surface: var(--color-code-block-surface-dark);
+}
+
+.code-block-body {
+  @apply relative;
+}
+
+.code-block-header {
+  @apply -mb-px flex items-end;
+}
+
+.code-block-lang {
+  @apply inline-block text-[0.7rem] leading-relaxed select-none;
+  padding: 0.2em 0.75em;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--color-primary);
+  background: var(--code-block-surface);
+  border: 1px solid var(--code-block-border);
+  border-bottom: none;
+  border-radius: 0.375rem 0.375rem 0 0;
+}
+
+.dark .code-block-lang {
+  color: var(--color-dark-text);
+}
+
+.prose-blog .code-block-wrapper pre.astro-code {
+  @apply m-0 px-5 py-4 text-inherit;
+  border: 1px solid var(--code-block-border);
+  border-radius: 0 0.375rem 0.375rem 0.375rem;
+  --shiki-light-bg: var(--code-block-surface) !important;
   background-color: var(--shiki-light-bg) !important;
   font-style: var(--shiki-light-font-style) !important;
   font-weight: var(--shiki-light-font-weight) !important;
   text-decoration: var(--shiki-light-text-decoration) !important;
 }
 
-.dark .astro-code {
+.code-block-wrapper:not(:has(.code-block-header))
+  .code-block-body
+  > pre.astro-code {
+  border-radius: 0.375rem;
+}
+
+.dark .prose-blog .code-block-wrapper pre.astro-code {
   background-color: var(--shiki-dark-bg) !important;
   color: var(--shiki-dark) !important;
 }
 
-.dark .astro-code span {
+.dark .prose-blog .code-block-wrapper pre.astro-code span {
   color: var(--shiki-dark) !important;
   font-style: var(--shiki-dark-font-style) !important;
   font-weight: var(--shiki-dark-font-weight) !important;
   text-decoration: var(--shiki-dark-text-decoration) !important;
 }
 
+.copy-btn {
+  @apply absolute top-2 right-2 z-10 flex cursor-pointer items-center justify-center gap-1 rounded-lg border-0 bg-transparent p-1.5 opacity-0 whitespace-nowrap;
+  color: var(--color-muted);
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.code-block-body:hover .copy-btn {
+  @apply opacity-100;
+}
+
+.copy-btn:hover {
+  @apply text-gray-700;
+  background-color: var(--color-hover-overlay-light);
+}
+
+.dark .copy-btn {
+  color: var(--color-muted-dark);
+}
+
+.dark .copy-btn:hover {
+  color: var(--color-dark-description);
+  background-color: var(--color-hover-overlay-dark);
+}
+
+.copy-btn.copied {
+  @apply opacity-100;
+  color: var(--color-success);
+}
+
+.copy-label {
+  @apply text-[0.7rem] font-medium leading-none;
+}
+
+.dark .copy-btn.copied {
+  color: var(--color-success-dark);
+}
+
+/* 라인 넘버 */
+.prose-blog .code-block-wrapper pre.astro-code code {
+  counter-reset: line;
+}
+
+.prose-blog .code-block-wrapper pre.astro-code .line::before {
+  counter-increment: line;
+  content: counter(line);
+  display: inline-block;
+  width: 1.5ch;
+  margin-right: 1.5rem;
+  text-align: right;
+  color: var(--color-muted);
+  user-select: none;
+  opacity: 0.75;
+  font-size: 0.85em;
+}
+
+.dark .prose-blog .code-block-wrapper pre.astro-code .line::before {
+  color: var(--color-muted-dark);
+}
+
 [data-tag] {
-  @apply bg-gray-100 text-gray-600 dark:bg-[#383B40] dark:text-[#9CA3AF];
+  background-color: var(--color-inline-code-surface);
+  color: var(--color-description);
+}
+
+.dark [data-tag] {
+  background-color: var(--color-tag-default-bg-dark);
+  color: var(--color-tag-default-text-dark);
 }
 
 /* React 브랜드 */


### PR DESCRIPTION
## Summary

- Shiki transformer + rehype 플러그인으로 빌드 타임에 코드 블록 래퍼 구조 주입 (lang탭 · copy버튼)
- Copy 버튼: hover 시 노출, 클릭 시 클립보드 복사 + ✓ Copied 피드백, 타이밍 버그 수정 (번쩍 방지)
- 라인 넘버 CSS 카운터, Shiki github-light/dark 테마 적용, Tailwind `@apply` 활용
- CSS 변수 토큰 정리 (`global.css`) 및 Header 브랜드 색상 변수화
- PR typecheck CI 워크플로우 추가 (`.github/workflows/ci.yml`)

## Test plan

- [ ] 코드 블록 hover 시 copy 버튼 노출 확인
- [ ] 클릭 후 ✓ Copied 표시 → 1.5초 후 자연스럽게 복귀 (번쩍 없음)
- [ ] lang 탭 있는 블록 / 없는 블록 border·radius 연결 확인
- [ ] 라이트 · 다크 모드 border 색상 확인
- [ ] CI typecheck 통과 확인