### PR TITLE
fix: /blogs 콘텐츠 영역을 헤더 로고와 좌측 정렬 + 컨테이너 확장

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -15,7 +15,7 @@ const NAV_ITEMS = [
   id="main-header"
 >
   <div
-    class="mx-auto flex h-full max-w-[1200px] items-center justify-between px-4 sm:px-6"
+    class="mx-auto flex h-full max-w-[1280px] items-center justify-between px-4 sm:px-6"
   >
     <a
       href="/"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -142,7 +142,7 @@ const jsonLd =
     class="dark:bg-dark text-dark m-0 min-h-full w-full bg-white transition-colors duration-300 dark:text-gray-50"
   >
     <Header />
-    <main class="mx-auto max-w-[1200px] px-4 sm:px-6">
+    <main class="mx-auto max-w-[1280px] px-4 sm:px-6">
       <slot />
     </main>
   </body>

--- a/src/styles/posts-page.css
+++ b/src/styles/posts-page.css
@@ -343,7 +343,8 @@
 /* 반응형 */
 @media (max-width: 768px) {
   .posts-page {
-    padding: 2rem 1rem 3rem;
+    padding-top: 2rem;
+    padding-bottom: 3rem;
   }
   .posts-content {
     flex-direction: column;
@@ -367,5 +368,14 @@
   }
   .post-tag {
     order: -1;
+  }
+}
+
+/* Header.astro의 px-4 → sm:px-6 전환(Tailwind 기본 브레이크포인트 640px)과
+   좌우 padding을 일치시키기 위한 전용 쿼리 */
+@media (max-width: 639px) {
+  .posts-page {
+    padding-left: 1rem;
+    padding-right: 1rem;
   }
 }

--- a/src/styles/posts-page.css
+++ b/src/styles/posts-page.css
@@ -1,7 +1,7 @@
 .posts-page {
-  max-width: 1088px;
+  max-width: 1200px;
   margin-inline: auto;
-  padding: 3rem 3.5rem 4.5rem;
+  padding: 3rem 1.5rem 4.5rem;
 }
 
 /* 헤딩 */
@@ -343,7 +343,7 @@
 /* 반응형 */
 @media (max-width: 768px) {
   .posts-page {
-    padding: 2rem 1.25rem 3rem;
+    padding: 2rem 1rem 3rem;
   }
   .posts-content {
     flex-direction: column;

--- a/src/styles/posts-page.css
+++ b/src/styles/posts-page.css
@@ -1,7 +1,7 @@
 .posts-page {
-  max-width: 1200px;
+  max-width: 1280px;
   margin-inline: auto;
-  padding: 3rem 1.5rem 4.5rem;
+  padding: 4rem 0;
 }
 
 /* 헤딩 */
@@ -368,14 +368,5 @@
   }
   .post-tag {
     order: -1;
-  }
-}
-
-/* Header.astro의 px-4 → sm:px-6 전환(Tailwind 기본 브레이크포인트 640px)과
-   좌우 padding을 일치시키기 위한 전용 쿼리 */
-@media (max-width: 639px) {
-  .posts-page {
-    padding-left: 1rem;
-    padding-right: 1rem;
   }
 }


### PR DESCRIPTION
## Summary
- `/blogs` 전체 글 페이지 콘텐츠 좌측 끝이 헤더 "Krong Dev." 로고 좌측 끝과 어긋나던 문제 수정
- `.posts-page`가 `<main>`과 별도로 자체 max-width/padding을 갖고 있어 이중으로 여백이 붙던 것이 원인
- 사이트 공통 컨테이너(Header + main)를 1200px → 1280px로 확장, `.posts-page`도 동일하게 맞춤
- `.posts-page`는 `<main>` 안에 중첩되므로 자체 좌우 padding 없이 `<main>`의 `px-4 sm:px-6`에만 의존하도록 정리 (이전에 남아있던 639px 전용 쿼리發 모바일 이중 padding도 제거)

## Test plan
- [x] `pnpm typecheck` (0 errors)
- [x] `pnpm dev` + curl로 `/blogs` 렌더 확인 (200, `.posts-page` 클래스 정상 출력)
- [x] 브라우저에서 라이트/다크 모드, 다양한 뷰포트 폭(375/640/768/1280px 경계)에서 실제 픽셀 정렬 육안 확인